### PR TITLE
fix:words 모바일 화면에서 drawer에서 dialog로 변경

### DIFF
--- a/app/components/worship-order/MessagePassageDrawer.tsx
+++ b/app/components/worship-order/MessagePassageDrawer.tsx
@@ -1,5 +1,3 @@
-import { Button } from "@/app/components/ui/button";
-import useIsDesktop from "@/app/hooks/useIsDestop";
 import {
   Dialog,
   DialogContent,
@@ -8,16 +6,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/app/components/ui/dialog";
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerTitle,
-  DrawerTrigger,
-} from "@/app/components/ui/drawer";
+
 import { useState } from "react";
 
 type MessagePassageDrawerProps = {
@@ -32,40 +21,18 @@ export default function MessagePassageDrawer({
   words,
 }: MessagePassageDrawerProps) {
   const [open, setOpen] = useState(false);
-  const isDesktop = useIsDesktop();
-  if (isDesktop) {
-    return (
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogTrigger asChild>{children}</DialogTrigger>
-        <DialogContent className="sm:max-w-[425px]">
-          <DialogHeader>
-            <DialogTitle>{passage}</DialogTitle>
-            {/* 개행 지키기 */}
-            <DialogDescription className="whitespace-pre-line overflow-y-auto">
-              {words}
-            </DialogDescription>
-          </DialogHeader>
-        </DialogContent>
-      </Dialog>
-    );
-  }
-
   return (
-    <Drawer open={open} onOpenChange={setOpen}>
-      <DrawerTrigger asChild>{children}</DrawerTrigger>
-      <DrawerContent>
-        <DrawerHeader className="text-left">
-          <DrawerTitle>{passage}</DrawerTitle>
-          <DrawerDescription className="whitespace-pre-line overflow-y-auto">
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>{passage}</DialogTitle>
+          {/* 개행 지키기 */}
+          <DialogDescription className="whitespace-pre-line overflow-y-auto">
             {words}
-          </DrawerDescription>
-        </DrawerHeader>
-        <DrawerFooter className="pt-2">
-          <DrawerClose asChild>
-            <Button variant="outline">닫기</Button>
-          </DrawerClose>
-        </DrawerFooter>
-      </DrawerContent>
-    </Drawer>
+          </DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
drawer 사용시 특정 브라우저에서 부모 페이지가 상단으로 이동하는 문제 발생으로 해당 컴포넌트 dialog 형식으로 변경